### PR TITLE
Add Python 3 support and move API Key to config

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -54,14 +54,15 @@ __contributors__ = {
 # This is a url where the most recent plugin package can be downloaded.
 __url__ = 'https://github.com/krf/supybot-lastfm'
 
-import config
-import plugin
+from . import config
+from . import plugin
+from imp import reload
 reload(plugin) # In case we're being reloaded.
 # Add more reloads here if you add third-party modules and want them to be
 # reloaded when this plugin is reloaded.  Don't forget to import them as well!
 
 if world.testing:
-    import test
+    from . import test
 
 Class = plugin.Class
 configure = config.configure

--- a/config.py
+++ b/config.py
@@ -41,9 +41,8 @@ def configure(advanced):
 
 
 LastFM = conf.registerPlugin('LastFM')
-# This is where your configuration variables (if any) should go.  For example:
-# conf.registerGlobalValue(LastFM, 'someConfigVariableName',
-#     registry.Boolean(False, """Help for someConfigVariableName."""))
+conf.registerGlobalValue(LastFM, 'apiKey',
+     registry.String('', """Sets the API key for this plugin: http://www.last.fm/api/account/create""", private=True))
 conf.registerChannelValue(LastFM, "maxResults",
     registry.NonNegativeInteger(5, """Limits the number of results that will be
         displayed in the channel."""))

--- a/plugin.py
+++ b/plugin.py
@@ -74,18 +74,18 @@ class LastFMParser:
         return (user, isNowPlaying, artist, track, album, time)
 
 class LastFM(callbacks.Plugin):
-    # 1.0 API (deprecated)
-    APIURL_1_0 = "http://ws.audioscrobbler.com/1.0/user"
-
-    # 2.0 API (see http://www.lastfm.de/api/intro)
-    APIKEY = "b7638a70725eea60737f9ad9f56f3099"
-    APIURL_2_0 = "http://ws.audioscrobbler.com/2.0/?api_key=%s&" % APIKEY
 
     def __init__(self, irc):
         self.__parent = super(LastFM, self)
         self.__parent.__init__(irc)
         self.db = LastFMDB(dbfilename)
         world.flushers.append(self.db.flush)
+        # 1.0 API (deprecated)
+        self.APIURL_1_0 = "http://ws.audioscrobbler.com/1.0/user"
+
+        # 2.0 API (see http://www.lastfm.de/api/intro)
+        self.apiKey = self.registryValue("apiKey")
+        self.APIURL_2_0 = "http://ws.audioscrobbler.com/2.0/?"
 
     def die(self):
         if self.db.flush in world.flushers:
@@ -102,6 +102,11 @@ class LastFM(callbacks.Plugin):
         Set your LastFM ID with the set method (default is your current nick)
         or specify <id> to switch for one call.
         """
+        if not self.apiKey:
+            irc.error("The API Key is not set for this plugin. Please set it via"
+                      "config plugins.lastfm.apikey and reload the plugin. "
+                      "You can sign up for an API Key using "
+                      "http://www.last.fm/api/account/create", Raise=True)
 
         id = (optionalId or self.db.getId(msg.nick) or msg.nick)
         channel = msg.args[0]
@@ -109,6 +114,7 @@ class LastFM(callbacks.Plugin):
         method = method.lower()
 
         url = "%s/%s/%s.txt" % (self.APIURL_1_0, id, method)
+        # url = "%sapi_key=%s&method=%s&user=%s" % (self.APIURL_2_0, self.apiKey, method, id)
         try:
             f = utils.web.getUrlFd(url)
         except utils.web.Error:
@@ -132,10 +138,15 @@ class LastFM(callbacks.Plugin):
         or specify <id> to switch for one call.
         """
 
+        if not self.apiKey:
+            irc.error("The API Key is not set for this plugin. Please set it via"
+                      "config plugins.lastfm.apikey and reload the plugin. "
+                      "You can sign up for an API Key using "
+                      "http://www.last.fm/api/account/create", Raise=True)
         id = (optionalId or self.db.getId(msg.nick) or msg.nick)
 
         # see http://www.lastfm.de/api/show/user.getrecenttracks
-        url = "%s&method=user.getrecenttracks&user=%s" % (self.APIURL_2_0, id)
+        url = "%sapi_key=%s&method=user.getrecenttracks&user=%s" % (self.APIURL_2_0, self.apiKey, id)
         try:
             f = utils.web.getUrlFd(url)
         except utils.web.Error:
@@ -144,7 +155,10 @@ class LastFM(callbacks.Plugin):
 
         parser = LastFMParser()
         (user, isNowPlaying, artist, track, album, time) = parser.parseRecentTracks(f)
-        albumStr = "[" + album + "]" if album else ""
+        if track is None:
+            irc.reply("%s doesn't seem to have listened to anything." % id)
+            return
+        albumStr = ("[%s]" % album) if album else ""
         if isNowPlaying:
             irc.reply('%s is listening to "%s" by %s %s'
                     % (user, track, artist, albumStr))
@@ -200,15 +214,18 @@ class LastFM(callbacks.Plugin):
         Compares the taste from two users
         If <user2> is ommitted, the taste is compared against the ID of the calling user.
         """
-
+        if not self.apiKey:
+            irc.error("The API Key is not set for this plugin. Please set it via"
+                      "config plugins.lastfm.apikey and reload the plugin. "
+                      "You can sign up for an API Key using "
+                      "http://www.last.fm/api/account/create", Raise=True)
         user2 = (optionalUser2 or self.db.getId(msg.nick) or msg.nick)
 
         channel = msg.args[0]
         maxResults = self.registryValue("maxResults", channel)
         # see http://www.lastfm.de/api/show/tasteometer.compare
-        url = "%s&method=tasteometer.compare&type1=user&type2=user&value1=%s&value2=%s&limit=%s" % (
-            self.APIURL_2_0, user1, user2, maxResults
-        )
+        url = "%sapi_key=%s&method=tasteometer.compare&type1=user&type2=user&value1=%s&value2=%s&limit=%s" % (
+            self.APIURL_2_0, self.apiKey, user1, user2, maxResults)
         try:
             f = utils.web.getUrlFd(url)
         except utils.web.Error as e:

--- a/plugin.py
+++ b/plugin.py
@@ -29,6 +29,7 @@
 
 ###
 
+from __future__ import unicode_literals
 import supybot.utils as utils
 from supybot.commands import *
 import supybot.conf as conf
@@ -38,11 +39,10 @@ import supybot.callbacks as callbacks
 import supybot.world as world
 import supybot.log as log
 
-import urllib2
 from xml.dom import minidom
 from time import time
 
-from LastFMDB import *
+from .LastFMDB import *
 
 class LastFMParser:
 
@@ -110,15 +110,13 @@ class LastFM(callbacks.Plugin):
 
         url = "%s/%s/%s.txt" % (self.APIURL_1_0, id, method)
         try:
-            f = urllib2.urlopen(url)
-        except urllib2.HTTPError:
+            f = utils.web.getUrlFd(url)
+        except utils.web.Error:
             irc.error("Unknown ID (%s) or unknown method (%s)"
-                    % (msg.nick, method))
-            return
+                    % (msg.nick, method), Raise=True)
 
-
-        lines = f.read().split("\n")
-        content = map(lambda s: s.split(",")[-1], lines)
+        lines = f.read().decode("utf-8").split("\n")
+        content = list(map(lambda s: s.split(",")[-1], lines))
 
         irc.reply("%s's %s: %s (with a total number of %i entries)"
                 % (id, method, ", ".join(content[0:maxResults]),
@@ -139,8 +137,8 @@ class LastFM(callbacks.Plugin):
         # see http://www.lastfm.de/api/show/user.getrecenttracks
         url = "%s&method=user.getrecenttracks&user=%s" % (self.APIURL_2_0, id)
         try:
-            f = urllib2.urlopen(url)
-        except urllib2.HTTPError:
+            f = utils.web.getUrlFd(url)
+        except utils.web.Error:
             irc.error("Unknown ID (%s)" % id)
             return
 
@@ -148,12 +146,12 @@ class LastFM(callbacks.Plugin):
         (user, isNowPlaying, artist, track, album, time) = parser.parseRecentTracks(f)
         albumStr = "[" + album + "]" if album else ""
         if isNowPlaying:
-            irc.reply(('%s is listening to "%s" by %s %s'
-                    % (user, track, artist, albumStr)).encode("utf8"))
+            irc.reply('%s is listening to "%s" by %s %s'
+                    % (user, track, artist, albumStr))
         else:
-            irc.reply(('%s listened to "%s" by %s %s more than %s'
+            irc.reply('%s listened to "%s" by %s %s more than %s'
                     % (user, track, artist, albumStr,
-                        self._formatTimeago(time))).encode("utf-8"))
+                        self._formatTimeago(time)))
 
     np = wrap(nowPlaying, [optional("something")])
 
@@ -182,8 +180,8 @@ class LastFM(callbacks.Plugin):
 
         url = "%s/%s/profile.xml" % (self.APIURL_1_0, id)
         try:
-            f = urllib2.urlopen(url)
-        except urllib2.HTTPError:
+            f = utils.web.getUrlFd(url)
+        except utils.web.Error:
             irc.error("Unknown user (%s)" % id)
             return
 
@@ -191,8 +189,8 @@ class LastFM(callbacks.Plugin):
         keys = "realname registered age gender country playcount".split()
         profile = tuple([self._parse(xml, node) for node in keys])
 
-        irc.reply(("%s (realname: %s) registered on %s; age: %s / %s; \
-Country: %s; Tracks played: %s" % ((id,) + profile)).encode("utf8"))
+        irc.reply("%s (realname: %s) registered on %s; age: %s / %s; "
+                  "Country: %s; Tracks played: %s" % ((id,) + profile))
 
     profile = wrap(profile, [optional("something")])
 
@@ -212,8 +210,8 @@ Country: %s; Tracks played: %s" % ((id,) + profile)).encode("utf8"))
             self.APIURL_2_0, user1, user2, maxResults
         )
         try:
-            f = urllib2.urlopen(url)
-        except urllib2.HTTPError, e:
+            f = utils.web.getUrlFd(url)
+        except utils.web.Error as e:
             irc.error("Failure: %s" % (e))
             return
 
@@ -224,10 +222,8 @@ Country: %s; Tracks played: %s" % ((id,) + profile)).encode("utf8"))
         # Note: XPath would be really cool here...
         artists = [el for el in resultNode.getElementsByTagName("artist")]
         artistNames = [el.getElementsByTagName("name")[0].firstChild.data for el in artists]
-        irc.reply(("Result of comparison between %s and %s: score: %s, common artists: %s" \
-                % (user1, user2, scoreStr, ", ".join(artistNames))
-            ).encode("utf-8")
-        )
+        irc.reply("Result of comparison between %s and %s: score: %s, common artists: %s" \
+                % (user1, user2, scoreStr, ", ".join(artistNames)))
 
     compare = wrap(compareUsers, ["something", optional("something")])
 

--- a/test.py
+++ b/test.py
@@ -31,7 +31,7 @@
 #from __future__ import print_function
 
 from supybot.test import *
-from plugin import LastFMParser
+from .plugin import LastFMParser
 
 from StringIO import StringIO
 

--- a/test.py
+++ b/test.py
@@ -28,33 +28,45 @@
 
 ###
 
-#from __future__ import print_function
-
 from supybot.test import *
 from .plugin import LastFMParser
 
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 class LastFMTestCase(PluginTestCase):
     plugins = ('LastFM',)
 
+    def setUp(self):
+        PluginTestCase.setUp(self)
+        apiKey = os.environ.get('lastfm_apikey')
+        if not apiKey:
+            e = ("The LastFM API key has not been set. "
+            "Please set the environment variable 'lastfm_apikey' "
+            "and try again. ('export lastfm_apikey=<apikey>' for those "
+            "using bash)")
+            raise callbacks.Error(e)
+        conf.supybot.plugins.LastFM.apiKey.setValue(apiKey)
+
     def testLastfm(self):
-        print self.assertNotError("lastfm recenttracks")
-        print self.assertError("lastfm TESTEXCEPTION")
-        print self.assertNotError("lastfm recenttracks czshadow")
-        print self.assertNotError("lastfm np krf")
+        self.assertNotError("lastfm recenttracks")
+        self.assertError("lastfm TESTEXCEPTION")
+        self.assertNotError("lastfm recenttracks czshadow")
+        self.assertNotError("lastfm np krf")
 
     def testLastfmDB(self):
-        print self.assertNotError("lastfm set nick") # test db
-        print self.assertNotError("lastfm set test") # test db unset
+        self.assertNotError("lastfm set nick") # test db
+        self.assertNotError("lastfm set test") # test db unset
 
     def testLastfmProfile(self):
-        print self.assertNotError("lastfm profile czshadow")
-        print self.assertNotError("lastfm profile test")
+        self.assertNotError("lastfm profile czshadow")
+        self.assertNotError("lastfm profile test")
 
     def testLastfmCompare(self):
-        print self.assertNotError("lastfm compare krf czshadow")
-        print self.assertNotError("lastfm compare krf")
+        self.assertNotError("lastfm compare krf czshadow")
+        self.assertNotError("lastfm compare krf")
 
     def testLastFMParseRecentTracks(self):
         """Parser tests"""


### PR DESCRIPTION
Some notes:
- This replaces use of urllib2 (which only exists on Python 2) with Supybot's built-in `utils.web.getUrlFd`, which is essentially a version-independent wrapper around it.
- This uses the `from __future__ import unicode_literals` feature from Python 2.6+, allowing all text to be handled as Unicode without having to use `encode()` (Python 3 does this already, but Python 2 does not).
- Import structure in `__init__.py` and `test.py` are updated to reflect Python 3's dropping of implicit relative imports (the new syntax works fine on Python 2).
- `test.py` will now load API Keys from an environment variable named `lastfm_apikey`.
